### PR TITLE
Clarify variable names

### DIFF
--- a/src/PIL/BdfFontFile.py
+++ b/src/PIL/BdfFontFile.py
@@ -64,16 +64,18 @@ def bdf_char(f):
         bitmap.append(s[:-1])
     bitmap = b"".join(bitmap)
 
-    # The word BBX followed by the width in x (BBw), height in y (BBh),
-    # and x and y displacement (BBox, BBoy) of the lower left corner
-    # from the origin of the character.
+    # The word BBX
+    # followed by the width in x (BBw), height in y (BBh),
+    # and x and y displacement (BBxoff0, BByoff0)
+    # of the lower left corner from the origin of the character.
     width, height, x_disp, y_disp = [int(p) for p in props["BBX"].split()]
 
-    # The word DWIDTH followed by the width in x and y of the character in device units.
-    dx, dy = [int(p) for p in props["DWIDTH"].split()]
+    # The word DWIDTH
+    # followed by the width in x and y of the character in device pixels.
+    dwx, dwy = [int(p) for p in props["DWIDTH"].split()]
 
     bbox = (
-        (dx, dy),
+        (dwx, dwy),
         (x_disp, -y_disp - height, width + x_disp, -y_disp),
         (0, 0, width, height),
     )

--- a/src/PIL/Image.py
+++ b/src/PIL/Image.py
@@ -765,17 +765,17 @@ class Image:
 
         bufsize = max(65536, self.size[0] * 4)  # see RawEncode.c
 
-        data = []
+        output = []
         while True:
-            length, error_code, chunk = e.encode(bufsize)
-            data.append(chunk)
-            if error_code:
+            bytes_consumed, errcode, data = e.encode(bufsize)
+            output.append(data)
+            if errcode:
                 break
-        if error_code < 0:
-            msg = f"encoder error {error_code} in tobytes"
+        if errcode < 0:
+            msg = f"encoder error {errcode} in tobytes"
             raise RuntimeError(msg)
 
-        return b"".join(data)
+        return b"".join(output)
 
     def tobitmap(self, name="image"):
         """

--- a/src/PIL/ImageFile.py
+++ b/src/PIL/ImageFile.py
@@ -530,20 +530,20 @@ def _encode_tile(im, fp, tile, bufsize, fh, exc=None):
             encoder.setimage(im.im, b)
             if encoder.pushes_fd:
                 encoder.setfd(fp)
-                length, error_code = encoder.encode_to_pyfd()
+                errcode = encoder.encode_to_pyfd()[1]
             else:
                 if exc:
                     # compress to Python file-compatible object
                     while True:
-                        length, error_code, chunk = encoder.encode(bufsize)
-                        fp.write(chunk)
-                        if error_code:
+                        errcode, data = encoder.encode(bufsize)[1:]
+                        fp.write(data)
+                        if errcode:
                             break
                 else:
                     # slight speedup: compress to real file object
-                    error_code = encoder.encode_to_file(fh, bufsize)
-            if error_code < 0:
-                msg = f"encoder error {error_code} when writing image file"
+                    errcode = encoder.encode_to_file(fh, bufsize)
+            if errcode < 0:
+                msg = f"encoder error {errcode} when writing image file"
                 raise OSError(msg) from exc
         finally:
             encoder.cleanup()

--- a/src/PIL/PcfFontFile.py
+++ b/src/PIL/PcfFontFile.py
@@ -86,7 +86,6 @@ class PcfFontFile(FontFile.FontFile):
 
         for ch, ix in enumerate(encoding):
             if ix is not None:
-                ix_metrics = metrics[ix]
                 (
                     xsize,
                     ysize,
@@ -96,7 +95,7 @@ class PcfFontFile(FontFile.FontFile):
                     ascent,
                     descent,
                     attributes,
-                ) = ix_metrics
+                ) = metrics[ix]
                 self.glyph[ch] = (
                     (width, 0),
                     (left, descent - ysize, xsize + left, descent),
@@ -220,9 +219,11 @@ class PcfFontFile(FontFile.FontFile):
             mode = "1"
 
         for i in range(nbitmaps):
-            x, y = metrics[i][0], metrics[i][1]
-            b, e = offsets[i], offsets[i + 1]
-            bitmaps.append(Image.frombytes("1", (x, y), data[b:e], "raw", mode, pad(x)))
+            left, right = metrics[i][:2]
+            b, e = offsets[i : i + 2]
+            bitmaps.append(
+                Image.frombytes("1", (left, right), data[b:e], "raw", mode, pad(left))
+            )
 
         return bitmaps
 

--- a/src/PIL/TiffImagePlugin.py
+++ b/src/PIL/TiffImagePlugin.py
@@ -1845,13 +1845,13 @@ def _save(im, fp, filename):
         e.setimage(im.im, (0, 0) + im.size)
         while True:
             # undone, change to self.decodermaxblock:
-            length, error_code, chunk = e.encode(16 * 1024)
+            errcode, data = e.encode(16 * 1024)[1:]
             if not _fp:
-                fp.write(chunk)
-            if error_code:
+                fp.write(data)
+            if errcode:
                 break
-        if error_code < 0:
-            msg = f"encoder error {error_code} when writing image file"
+        if errcode < 0:
+            msg = f"encoder error {errcode} when writing image file"
             raise OSError(msg)
 
     else:


### PR DESCRIPTION
Suggestions for https://github.com/python-pillow/Pillow/pull/6971

Rather than `length, error_code, chunk`, I suggest we use [existing variable names from another part of Pillow.](https://github.com/python-pillow/Pillow/blob/879e77a44604b31e271711898b035a5caba8cb73/src/PIL/ImageFile.py#L754)

I've also adjusted the BDF variable names and comments to better match the [specification](https://adobe-type-tools.github.io/font-tech-notes/pdfs/5005.BDF_Spec.pdf).
> DWIDTH specifies the widths in x and y, dwx0 and dwy0, in device pixels.

> BBX is fllowed by BBw, the width of the black pixels in x, and BBh, the height in y. These are followed by the x and y displacement, BBxoff0 and BByoff0, of the lower left corner of the bitmap from origin 0.
