### PR TITLE
Corrected lut mode

### DIFF
--- a/Tests/test_color_lut.py
+++ b/Tests/test_color_lut.py
@@ -106,39 +106,39 @@ class TestColorLut3DCoreAPI:
             im.im.color_lut_3d("RGB", Image.Resampling.BILINEAR, 3, 2, 2, 2, 16)
 
     @pytest.mark.parametrize(
-        "lut_mode, table_size",
+        "lut_mode, table_channels, table_size",
         [
-            ("RGB", (3, 3)),
-            ("CMYK", (4, 3)),
-            ("RGB", (3, (2, 3, 3))),
-            ("RGB", (3, (65, 3, 3))),
-            ("RGB", (3, (3, 65, 3))),
-            ("RGB", (3, (3, 3, 65))),
+            ("RGB", 3, 3),
+            ("CMYK", 4, 3),
+            ("RGB", 3, (2, 3, 3)),
+            ("RGB", 3, (65, 3, 3)),
+            ("RGB", 3, (3, 65, 3)),
+            ("RGB", 3, (2, 3, 65)),
         ],
     )
     def test_correct_args(
-        self, lut_mode: str, table_size: tuple[int, int | tuple[int, int, int]]
+        self, lut_mode: str, table_channels: int, table_size: int | tuple[int, int, int]
     ) -> None:
         im = Image.new("RGB", (10, 10), 0)
         assert im.im is not None
         im.im.color_lut_3d(
             lut_mode,
             Image.Resampling.BILINEAR,
-            *self.generate_identity_table(*table_size),
+            *self.generate_identity_table(table_channels, table_size),
         )
 
     @pytest.mark.parametrize(
-        "image_mode, lut_mode, table_size",
+        "image_mode, lut_mode, table_channels, table_size",
         [
-            ("L", "RGB", (3, 3)),
-            ("RGB", "L", (3, 3)),
-            ("L", "L", (3, 3)),
-            ("RGB", "RGBA", (3, 3)),
-            ("RGB", "RGB", (4, 3)),
+            ("L", "RGB", 3, 3),
+            ("RGB", "L", 3, 3),
+            ("L", "L", 3, 3),
+            ("RGB", "RGBA", 3, 3),
+            ("RGB", "RGB", 4, 3),
         ],
     )
     def test_wrong_mode(
-        self, image_mode: str, lut_mode: str, table_size: tuple[int, int]
+        self, image_mode: str, lut_mode: str, table_channels: int, table_size: int
     ) -> None:
         with pytest.raises(ValueError, match="wrong mode"):
             im = Image.new(image_mode, (10, 10), 0)
@@ -146,27 +146,27 @@ class TestColorLut3DCoreAPI:
             im.im.color_lut_3d(
                 lut_mode,
                 Image.Resampling.BILINEAR,
-                *self.generate_identity_table(*table_size),
+                *self.generate_identity_table(table_channels, table_size),
             )
 
     @pytest.mark.parametrize(
-        "image_mode, lut_mode, table_size",
+        "image_mode, lut_mode, table_channels, table_size",
         [
-            ("RGBA", "RGBA", (3, 3)),
-            ("RGBA", "RGBA", (4, 3)),
-            ("RGB", "HSV", (3, 3)),
-            ("RGB", "RGBA", (4, 3)),
+            ("RGBA", "RGBA", 3, 3),
+            ("RGBA", "RGBA", 4, 3),
+            ("RGB", "HSV", 3, 3),
+            ("RGB", "RGBA", 4, 3),
         ],
     )
     def test_correct_mode(
-        self, image_mode: str, lut_mode: str, table_size: tuple[int, int]
+        self, image_mode: str, lut_mode: str, table_channels: int, table_size: int
     ) -> None:
         im = Image.new(image_mode, (10, 10), 0)
         assert im.im is not None
         im.im.color_lut_3d(
             lut_mode,
             Image.Resampling.BILINEAR,
-            *self.generate_identity_table(*table_size),
+            *self.generate_identity_table(table_channels, table_size),
         )
 
     def test_identities(self) -> None:

--- a/Tests/test_color_lut.py
+++ b/Tests/test_color_lut.py
@@ -106,7 +106,7 @@ class TestColorLut3DCoreAPI:
             im.im.color_lut_3d("RGB", Image.Resampling.BILINEAR, 3, 2, 2, 2, 16)
 
     @pytest.mark.parametrize(
-        ("lut_mode", "table_size"),
+        "lut_mode, table_size",
         [
             ("RGB", (3, 3)),
             ("CMYK", (4, 3)),
@@ -128,7 +128,7 @@ class TestColorLut3DCoreAPI:
         )
 
     @pytest.mark.parametrize(
-        ("image_mode", "lut_mode", "table_size"),
+        "image_mode, lut_mode, table_size",
         [
             ("L", "RGB", (3, 3)),
             ("RGB", "L", (3, 3)),
@@ -150,7 +150,7 @@ class TestColorLut3DCoreAPI:
             )
 
     @pytest.mark.parametrize(
-        ("image_mode", "lut_mode", "table_size"),
+        "image_mode, lut_mode, table_size",
         [
             ("RGBA", "RGBA", (3, 3)),
             ("RGBA", "RGBA", (4, 3)),

--- a/Tests/test_color_lut.py
+++ b/Tests/test_color_lut.py
@@ -152,7 +152,7 @@ class TestColorLut3DCoreAPI:
     @pytest.mark.parametrize(
         ("image_mode", "lut_mode", "table_size"),
         [
-            ("RGBA", "RGB", (3, 3)),
+            ("RGBA", "RGBA", (3, 3)),
             ("RGBA", "RGBA", (4, 3)),
             ("RGB", "HSV", (3, 3)),
             ("RGB", "RGBA", (4, 3)),


### PR DESCRIPTION
Suggestions for https://github.com/python-pillow/Pillow/pull/8290

- The first `test_correct_mode()` `lut_mode` should be RGBA
- Replaced `("lut_mode", "table_size")` with `"lut_mode, table_size"`. It seems simpler to me, and is [the style that Pillow is using elsewhere](https://github.com/python-pillow/Pillow/blob/11b4df3ff9c02757eaf687ac13374f3525c8cb71/Tests/test_file_tiff_metadata.py#L195)
- The second argument of [`generate_identity_table()` is `size`](https://github.com/python-pillow/Pillow/blob/11b4df3ff9c02757eaf687ac13374f3525c8cb71/Tests/test_color_lut.py#L20-L22), so I've split `table_size` into `table_channels` and `table_size`